### PR TITLE
Start using strongly typed Paramters for EdifactFormat and EdifactFormatVersion

### DIFF
--- a/.github/workflows/unittests_and_coverage.yml
+++ b/.github/workflows/unittests_and_coverage.yml
@@ -28,4 +28,4 @@ jobs:
         working-directory: ./EDILibraryTests
         run: dotnet add package coverlet.msbuild
       - name: Measure Test Coverage
-        run: dotnet test /p:Threshold=7 /p:Include=\"[*]EDILibrary.*\" /p:ThresholdType=line /p:CollectCoverage=true /p:SkipAutoProps=true /p:CoverletOutputFormat=lcov --configuration Release
+        run: dotnet test /p:Threshold=8 /p:Include=\"[*]EDILibrary.*\" /p:ThresholdType=line /p:CollectCoverage=true /p:SkipAutoProps=true /p:CoverletOutputFormat=lcov --configuration Release

--- a/EDIFileLoader/AzureStorageLoader.cs
+++ b/EDIFileLoader/AzureStorageLoader.cs
@@ -73,14 +73,14 @@ namespace EDIFileLoader
             {
                 try
                 {
-                    return Cache["edi"][Path.Combine("edi", info.Format, info.Format + info.Version + "." + type).Replace("\\", "/")];
+                    return Cache["edi"][Path.Combine("edi", info.Format.ToString(), info.Format.ToString() + info.Version + "." + type).Replace("\\", "/")];
                 }
                 catch (Exception)
                 {
                     // todo: no pokemon-catcher
                 }
             }
-            var blockBlob = _container.GetBlobClient(Path.Combine("edi", info.Format, info.Format + info.Version + "." + type));
+            var blockBlob = _container.GetBlobClient(Path.Combine("edi", info.Format.ToString(), info.Format.ToString() + info.Version + "." + type));
 
             string text = await new StreamReader((await blockBlob.DownloadAsync()).Value.Content, Encoding.UTF8).ReadToEndAsync();
             text = EDIHelper.RemoveByteOrderMark(text);
@@ -90,20 +90,27 @@ namespace EDIFileLoader
         {
             throw new NotSupportedException();
         }
+
+        [Obsolete("Use strongly typed version instead.")]
         public async Task<string> LoadJSONTemplate(string formatPackage, string fileName)
+        {
+            return await LoadJSONTemplate(formatPackage.ToEdifactFormatVersion(), fileName);
+        }
+
+        public async Task<string> LoadJSONTemplate(EdifactFormatVersion formatPackage, string fileName)
         {
             if (Cache != null)
             {
                 try
                 {
-                    return Cache["edi"][Path.Combine(formatPackage.Replace("/", ""), fileName.Replace("\\", "/"))];
+                    return Cache["edi"][Path.Combine(formatPackage.ToLegacyVersionString().Replace("/", ""), fileName.Replace("\\", "/"))];
                 }
                 catch (Exception)
                 {
                     // todo: no pokemon-catcher
                 }
             }
-            var blockBlob = _container.GetBlobClient(System.IO.Path.Combine(formatPackage.Replace("/", ""), fileName).Replace("\\", "/"));
+            var blockBlob = _container.GetBlobClient(System.IO.Path.Combine(formatPackage.ToLegacyVersionString().Replace("/", ""), fileName).Replace("\\", "/"));
 
             string text = await new StreamReader((await blockBlob.DownloadAsync()).Value.Content, Encoding.UTF8).ReadToEndAsync();
             text = EDIHelper.RemoveByteOrderMark(text);

--- a/EDILibrary/EDIFACTEnums.cs
+++ b/EDILibrary/EDIFACTEnums.cs
@@ -169,7 +169,5 @@ namespace EDILibrary
         Referenz,
         [Description("Version")]
         Version
-
-
     }
 }

--- a/EDILibrary/EDIHelper.cs
+++ b/EDILibrary/EDIHelper.cs
@@ -52,6 +52,9 @@ namespace EDILibrary
         /// e.g. 5.2h
         /// </summary>
         public string Version;
+        /// <summary>
+        /// EDIFACT format if set. Null in case of error (formerly: "ERROR")
+        /// </summary>
         public EdifactFormat? Format;
         public EDIPartner Sender;
         public EDIPartner Empfänger;

--- a/EDILibrary/EDIHelper.cs
+++ b/EDILibrary/EDIHelper.cs
@@ -48,8 +48,11 @@ namespace EDILibrary
 
     public class EDIFileInfo : IEquatable<EDIFileInfo>
     {
+        /// <summary>
+        /// e.g. 5.2h
+        /// </summary>
         public string Version;
-        public string Format;
+        public EdifactFormat? Format;
         public EDIPartner Sender;
         public EDIPartner Empfänger;
         public string ID;
@@ -62,7 +65,7 @@ namespace EDILibrary
             return string.Join("_",
                 new List<string>
                 {
-                    Format, Referenz, Sender != null ? Sender.ToString() : "", Empfänger != null ? Empfänger.ToString() : "", DateTime.UtcNow.ToString("yyyyMMdd"), ID
+                    this.Format.ToString(), Referenz, Sender != null ? Sender.ToString() : "", Empfänger != null ? Empfänger.ToString() : "", DateTime.UtcNow.ToString("yyyyMMdd"), ID
                 });
         }
 
@@ -70,7 +73,7 @@ namespace EDILibrary
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Version == other.Version && Format == other.Format && Equals(Sender, other.Sender) && Equals(Empfänger, other.Empfänger) && ID == other.ID &&
+            return Version == other.Version && this.Format == other.Format && Equals(Sender, other.Sender) && Equals(Empfänger, other.Empfänger) && ID == other.ID &&
                    Referenz == other.Referenz && Freigabenummer == other.Freigabenummer && Nachrichtenversion == other.Nachrichtenversion;
         }
 
@@ -244,20 +247,24 @@ namespace EDILibrary
                 EDIFileInfo file = new EDIFileInfo
                 {
                     Empfänger = empfänger,
-                    Sender = sender
+                    Sender = sender,
+                    ID = unbParts[5].Split(specialChars.ElementDelimiter.ToCharArray())[0],
+                    Format = Enum.Parse<EdifactFormat>(unhParts[2].Split(specialChars.ElementDelimiter.ToCharArray())[0]),
+                    Version = unhParts[2].Split(specialChars.ElementDelimiter.ToCharArray())[4],
+                    Freigabenummer = unhParts[2].Split(specialChars.ElementDelimiter.ToCharArray())[2],
+                    Nachrichtenversion = unhParts[2].Split(specialChars.ElementDelimiter.ToCharArray())[1]
                 };
                 if (unbParts.Length >= 7)
                     file.Referenz = unbParts[7].Split(specialChars.ElementDelimiter.ToCharArray())[0];
-                file.ID = unbParts[5].Split(specialChars.ElementDelimiter.ToCharArray())[0];
-                file.Format = unhParts[2].Split(specialChars.ElementDelimiter.ToCharArray())[0];
-                file.Version = unhParts[2].Split(specialChars.ElementDelimiter.ToCharArray())[4];
-                file.Freigabenummer = unhParts[2].Split(specialChars.ElementDelimiter.ToCharArray())[2];
-                file.Nachrichtenversion = unhParts[2].Split(specialChars.ElementDelimiter.ToCharArray())[1];
                 return file;
             }
             catch (Exception)
             {
-                return new EDIFileInfo { Format = "ERROR", Referenz = Guid.NewGuid().ToString() };
+                return new EDIFileInfo
+                {
+                    Format = null,
+                    Referenz = Guid.NewGuid().ToString()
+                };
             }
         }
     }

--- a/EDILibrary/EdiJsonMapper.cs
+++ b/EDILibrary/EdiJsonMapper.cs
@@ -26,7 +26,10 @@ namespace EDILibrary
         public struct JsonResult
         {
             public string EDI;
-            public string Format;
+            public EdifactFormat? Format;
+            /// <summary>
+            /// e.g. 5.2h
+            /// </summary>
             public string Version;
             public string Sender;
             public string Receiver;
@@ -59,14 +62,14 @@ namespace EDILibrary
                 package = edi_info.Format + "|" + edi_info.Version;
             }
             //mapping laden
-            JArray mappings = null;
+            JArray mappings;
             try
             {
                 mappings = JsonConvert.DeserializeObject<JArray>(await _loader.LoadJSONTemplate(package, edi_info.Format + ".json"));
             }
             catch (Exception e)
             {
-                throw new BadFormatException(edi_info.Format, edi_info.Version);
+                throw new BadFormatException(edi_info.Format, edi_info.Version, e);
             }
             dynamic resultObject = new ExpandoObject();
 
@@ -82,36 +85,17 @@ namespace EDILibrary
             };
             return result;
         }
-        public async Task<string> CreateFromJson(string jsonInput, string pid, string formatPackage = null, bool convertFromUTC = false)
+
+        [Obsolete("Use strongly typed overload instead.")]
+        public async Task<string> CreateFromJson(string jsonInput, string pid, string formatPackage, bool convertFromUTC = false)
         {
-            //format is derived from the pid
-            string format = pid.Substring(0, 2) switch
-            {
-                "11" => "UTILMD",
-                "13" => "MSCONS",
-                "17" => "ORDERS",
-                "19" => "ORDRSP",
-                "21" => "IFTSTA",
-                "70" => "SSQNOT",
-                "31" => "INVOIC",
-                "33" => "REMADV",
-                "27" => "PRICAT",
-                "35" => "REQOTE",
-                "15" => "QUOTES",
-                "23" => "INSRPT",
-                "25" => "UTILTS",
-                "99" => "APERAK",
-                _ => "ERROR"
-            };
-            string package;
-            if (formatPackage != null)
-            {
-                package = formatPackage;
-            }
-            else
-            {
-                throw new Exception("FormatPackage must be specified");
-            }
+            return await CreateFromJson(jsonInput, pid, formatPackage.ToEdifactFormatVersion(), convertFromUTC);
+        }
+
+        public async Task<string> CreateFromJson(string jsonInput, string pid, EdifactFormatVersion formatPackage, bool convertFromUTC = false)
+        {
+            var format = EdifactFormatHelper.FromPruefidentifikator(pid);
+            var package = formatPackage;
             var json = JsonConvert.DeserializeObject<JObject>(await _loader.LoadJSONTemplate(package, $"{pid}.json"));
             var inputJson = JsonConvert.DeserializeObject<JObject>(jsonInput);
             JArray mappings = JsonConvert.DeserializeObject<JArray>(await _loader.LoadJSONTemplate(package, format + ".json"));
@@ -129,7 +113,7 @@ namespace EDILibrary
             //    {
             //       throw new BadPIDException(pid);
             //    }
-            string version = mappings[0]["_meta"]["version"].Value<string>();
+            var version = mappings[0]["_meta"]["version"].Value<string>();
 
             JArray maskArray = new JArray();
             foreach (var step in json.Property("steps").Value)
@@ -148,7 +132,11 @@ namespace EDILibrary
             var outputJson = CreateMsgJSON(inputJson, mappings, maskArray, out var subParent, convertFromUTC);
             IEdiObject result = IEdiObject.CreateFromJSON(JsonConvert.SerializeObject(outputJson));
             //apply scripts
-            return await new MappingHelper().ExecuteMappings(result, new EDIFileInfo { Format = format, Version = version }, new List<string>(), _loader, convertFromUTC);
+            return await new MappingHelper().ExecuteMappings(result, new EDIFileInfo
+            {
+                Format = format,
+                Version = version,
+            }, new List<string>(), _loader, convertFromUTC);
 
         }
         protected void ParseObject(JObject value, IDictionary<string, object> target, JArray mappings, bool includeEmptyValues)

--- a/EDILibrary/EdifactFormatVersion.cs
+++ b/EDILibrary/EdifactFormatVersion.cs
@@ -1,0 +1,255 @@
+﻿using System;
+
+namespace EDILibrary
+{
+    /// <summary>
+    /// A EDIFACT Format is one of the different formats used in German market communication.
+    /// Each Format uses a different Message Implementation Guide ("MIG"). EdifactFormats are stable over time.
+    /// To model different versions of the same format use <see cref="EdifactFormatVersion"/>.
+    /// </summary>
+    public enum EdifactFormat
+    {
+        /// <summary>
+        /// Multimodaler Statusbericht
+        /// </summary>
+        IFTSTA = 21,
+
+        /// <summary>
+        /// Prüfbericht
+        /// </summary>
+        INSRPT = 23,
+
+        /// <summary>
+        /// invoices
+        /// </summary>
+        INVOIC = 31,
+
+        /// <summary>
+        /// meter readings and energy amounts
+        /// </summary>
+        MSCONS = 13,
+
+        /// <summary>
+        /// Bestellung
+        /// </summary>
+        ORDERS = 17,
+
+        /// <summary>
+        /// Bestellantwort
+        /// </summary>
+        ORDRSP = 19,
+
+        /// <summary>
+        /// price catalogues
+        /// </summary>
+        PRICAT = 27,
+
+        /// <summary>
+        /// quotes
+        /// </summary>
+        QUOTES = 35,
+
+        /// <summary>
+        /// Zahlungsavis
+        /// </summary>
+        REMADV = 33,
+
+        /// <summary>
+        /// Anfrage
+        /// </summary>
+        REQOTE = 15,
+
+        /// <summary>
+        /// master data
+        /// </summary>
+        UTILMD = 11
+    }
+
+    /// <summary>
+    /// contains helper methods to derive the <see cref="EdifactFormat"/> from e.g. the Prüfidentifikator
+    /// </summary>
+    public static class EdifactFormatHelper
+    {
+        /// <summary>
+        /// get fact for a message class ID ("Prüfidentifikator")
+        /// </summary>
+        /// <param name="pruefidentifikator">prüfidentifikator, e.g. '11042'</param>
+        /// <returns>the EdifactFormat, e.g. <see cref="EdifactFormat.UTILMD"/> or throws a NotImplementedException iff EdiFormat was found</returns>
+        public static EdifactFormat FromPruefidentifikator(string pruefidentifikator)
+        {
+            if (string.IsNullOrWhiteSpace(pruefidentifikator)) throw new ArgumentNullException(nameof(pruefidentifikator));
+            foreach (EdifactFormat ef in Enum.GetValues(typeof(EdifactFormat)))
+            {
+                if (pruefidentifikator.StartsWith(((int)ef).ToString()))
+                {
+                    return ef;
+                }
+            }
+
+            throw new NotImplementedException($"No matching EdiFormat found for Prüfidentifikator {pruefidentifikator}");
+        }
+    }
+
+    /// <summary>
+    /// A Format Version represents a validity period of a EDIFACT format
+    /// </summary>
+    public enum EdifactFormatVersion
+    {
+        /// <summary>
+        /// format version valid since 2017-10-01
+        /// </summary>
+        FV1710,
+
+        /// <summary>
+        /// format version valid since 2019-04-01
+        /// </summary>
+        FV1904,
+
+        /// <summary>
+        /// format version valid since 2019-12-01 ("Mako2020")
+        /// </summary>
+        FV1912,
+
+        /// <summary>
+        /// format version valid since 2020-04-01
+        /// </summary>
+        FV2004,
+
+        /// <summary>
+        /// Format Version April 2021 (valid since 2021-04-01)
+        /// </summary>
+        FV2104,
+
+        /// <summary>
+        /// Format Version October 2021 (valid since 2021-10-01)
+        /// </summary>
+        FV2110,
+
+        /// <summary>
+        /// Format Version April 2022 (aka MaKo2022)
+        /// </summary>
+        FV2204
+    }
+
+    /// <summary>
+    /// Extension methods for <see cref="EdifactFormatVersion"/>
+    /// </summary>
+    public static class EdifactFormatVersionExtension
+    {
+        /// <summary>
+        /// returns the legacy "MM/YY" string for a <see cref="EdifactFormatVersion"/>.
+        /// </summary>
+        /// <remarks>It's called legacy because its unhandy (modelling enums with leading digits or slashes is complicated and unintuitive to use the month before the year.</remarks>
+        /// <param name="edifactFormatVersion"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public static string ToLegacyVersionString(this EdifactFormatVersion edifactFormatVersion)
+        {
+            return edifactFormatVersion switch
+            {
+                EdifactFormatVersion.FV1710 => "10/17",
+                EdifactFormatVersion.FV1904 => "04/19",
+                EdifactFormatVersion.FV1912 => "12/19",
+                EdifactFormatVersion.FV2004 => "04/20",
+                EdifactFormatVersion.FV2104 => "04/21",
+                EdifactFormatVersion.FV2110 => "10/21",
+                EdifactFormatVersion.FV2204 => "04/22",
+                _ => throw new NotImplementedException($"The legacy format for {edifactFormatVersion} is not yet implemented.")
+            };
+        }
+
+        /// <summary>
+        /// parses the <paramref name="legacyFormatString"/> as <see cref="EdifactFormatVersion"/>.
+        /// If <paramref name="legacyFormatString"/> is null or white space, the current version is returned.
+        /// </summary>
+        /// <param name="legacyFormatString"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public static EdifactFormatVersion ToEdifactFormatVersion(this string legacyFormatString)
+        {
+            if (string.IsNullOrWhiteSpace(legacyFormatString)) return EdifactFormatVersionHelper.GetCurrent();
+            foreach (var efv in Enum.GetValues<EdifactFormatVersion>())
+            {
+                if (legacyFormatString == efv.ToLegacyVersionString())
+                {
+                    return efv;
+                }
+            }
+
+            if (Enum.TryParse<EdifactFormatVersion>(legacyFormatString, out var result))
+            {
+                // may we'll ever receive it in the new format. then transformer bee will be the last system to complain ;)
+                return result;
+            }
+
+            throw new NotImplementedException($"The legacy format string '{legacyFormatString}' could not be mapped.");
+        }
+    }
+
+    public static class EdifactFormatVersionHelper
+    {
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV1904"/>
+        /// </summary>
+        private static readonly DateTime Keydate1904 = new(2019, 3, 31, 22, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV1912"/>
+        /// </summary>
+        private static readonly DateTime Keydate1912 = new(2019, 11, 30, 23, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2004"/>
+        /// </summary>
+        private static readonly DateTime Keydate2004 = new(2020, 03, 31, 22, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2104"/>
+        /// </summary>
+        private static readonly DateTime Keydate2104 = new(2021, 03, 31, 22, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2110"/>
+        /// </summary>
+        private static readonly DateTime KeyDate2110 = new(2021, 09, 30, 22, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2110"/>
+        /// </summary>
+        private static readonly DateTime KeyDate2204 = new(2022, 03, 31, 22, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// returns the format version valid as of now.
+        /// </summary>
+        /// <returns>currently valid EdiFormatVersion (the oldest one implemented is <see cref="EdifactFormatVersion.FV1710"/></returns>
+        public static EdifactFormatVersion GetCurrent()
+        {
+            var now = DateTime.UtcNow;
+            if (now > KeyDate2204)
+            {
+                return EdifactFormatVersion.FV2204;
+            }
+            if (now > KeyDate2110)
+            {
+                return EdifactFormatVersion.FV2110;
+            }
+            if (now > Keydate2104)
+            {
+                return EdifactFormatVersion.FV2104;
+            }
+            if (now > Keydate2004)
+            {
+                return EdifactFormatVersion.FV2004;
+            }
+            if (now > Keydate1912)
+            {
+                return EdifactFormatVersion.FV1912;
+            }
+            if (now > Keydate1904)
+            {
+                return EdifactFormatVersion.FV1904;
+            }
+            return EdifactFormatVersion.FV1710;
+        }
+    }
+}

--- a/EDILibrary/Exceptions/BadFormatException.cs
+++ b/EDILibrary/Exceptions/BadFormatException.cs
@@ -8,21 +8,21 @@ namespace EDILibrary.Exceptions
     /// <seealso cref="BadPIDException"/>
     public class BadFormatException : Exception
     {
-        private string _format;
+        private EdifactFormat? _format;
+        /// <summary>
+        /// e.g. 5.2h
+        /// </summary>
         private string _version;
 
-        /// <inheritdoc />
-        public override string Message => $"Format {_format} in version {_version} could not be found";
-
-        /// <summary>
-        /// Initialize the Exception by providing both the (stringly typed) format and the version.
-        /// </summary>
-        /// <param name="format"></param>
-        /// <param name="version"></param>
-        public BadFormatException(string format, string version)
+        public BadFormatException(EdifactFormat? format, string version, Exception innerException) : base($"Format {format} in version {version} could not be found", innerException)
         {
-            _format = format;
-            _version = version;
+            this._format = format;
+            this._version = version;
+        }
+
+        [Obsolete("Use strongly typed overload instead")]
+        public BadFormatException(string format, string version, Exception innerException) : this(Enum.Parse<EdifactFormat>(format), version, innerException)
+        {
         }
     }
 }

--- a/EDILibrary/ExtendedMappings.cs
+++ b/EDILibrary/ExtendedMappings.cs
@@ -65,9 +65,9 @@ namespace EDILibrary
             }
         }
 
-        public void ExecuteMapping(string mappingName, IEdiObject obj, string sparte, string format)
+        public void ExecuteMapping(string mappingName, IEdiObject obj, string sparte, EdifactFormat? format)
         {
-            XElement mapping = _mappingRoot.FirstOrDefault(mr => mr.Attribute("Name").Value == mappingName && (mr.Attribute("format") == null || mr.Attribute("format").Value == format));
+            XElement mapping = _mappingRoot.FirstOrDefault(mr => mr.Attribute("Name").Value == mappingName && (mr.Attribute("format") == null || Enum.Parse<EdifactFormat>(mr.Attribute("format").Value) == format));
             if (mapping != null)
             {
                 if (mapping.Attribute("type") == null || mapping.Attribute("type")?.Value == "python")

--- a/EDILibrary/Interfaces/ITemplateLoader.cs
+++ b/EDILibrary/Interfaces/ITemplateLoader.cs
@@ -9,7 +9,14 @@ namespace EDILibrary.Interfaces
     {
         Task<string> LoadEDITemplate(EDIFileInfo info, string type);
         Task<string> LoadJSONTemplate(string fileName);
-        Task<string> LoadJSONTemplate(EdifactFormatVersion formatPackage, string fileName);
+        /// <summary>
+        /// todo @JoschaMetze add docstring
+        /// </summary>
+        /// <param name="format"></param>
+        /// <param name="version">e.g. 5.2h</param>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        Task<string> LoadJSONTemplate(EdifactFormat? format, string version, string fileName);
 
         [Obsolete("Use strongly typed overload")]
         Task<string> LoadJSONTemplate(string formatPackage, string fileName);

--- a/EDILibrary/Interfaces/ITemplateLoader.cs
+++ b/EDILibrary/Interfaces/ITemplateLoader.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2017 Hochfrequenz Unternehmensberatung GmbH
 
+using System;
 using System.Threading.Tasks;
 
 namespace EDILibrary.Interfaces
@@ -8,6 +9,9 @@ namespace EDILibrary.Interfaces
     {
         Task<string> LoadEDITemplate(EDIFileInfo info, string type);
         Task<string> LoadJSONTemplate(string fileName);
+        Task<string> LoadJSONTemplate(EdifactFormatVersion formatPackage, string fileName);
+
+        [Obsolete("Use strongly typed overload")]
         Task<string> LoadJSONTemplate(string formatPackage, string fileName);
     }
 }

--- a/EDILibraryBase/EdifactFormatVersion.cs
+++ b/EDILibraryBase/EdifactFormatVersion.cs
@@ -1,0 +1,256 @@
+﻿using System;
+using System.Linq;
+
+namespace EDILibrary
+{
+    /// <summary>
+    /// A EDIFACT Format is one of the different formats used in German market communication.
+    /// Each Format uses a different Message Implementation Guide ("MIG"). EdifactFormats are stable over time.
+    /// To model different versions of the same format use <see cref="EdifactFormatVersion"/>.
+    /// </summary>
+    public enum EdifactFormat
+    {
+        /// <summary>
+        /// Multimodaler Statusbericht
+        /// </summary>
+        IFTSTA = 21,
+
+        /// <summary>
+        /// Prüfbericht
+        /// </summary>
+        INSRPT = 23,
+
+        /// <summary>
+        /// invoices
+        /// </summary>
+        INVOIC = 31,
+
+        /// <summary>
+        /// meter readings and energy amounts
+        /// </summary>
+        MSCONS = 13,
+
+        /// <summary>
+        /// Bestellung
+        /// </summary>
+        ORDERS = 17,
+
+        /// <summary>
+        /// Bestellantwort
+        /// </summary>
+        ORDRSP = 19,
+
+        /// <summary>
+        /// price catalogues
+        /// </summary>
+        PRICAT = 27,
+
+        /// <summary>
+        /// quotes
+        /// </summary>
+        QUOTES = 35,
+
+        /// <summary>
+        /// Zahlungsavis
+        /// </summary>
+        REMADV = 33,
+
+        /// <summary>
+        /// Anfrage
+        /// </summary>
+        REQOTE = 15,
+
+        /// <summary>
+        /// master data
+        /// </summary>
+        UTILMD = 11
+    }
+
+    /// <summary>
+    /// contains helper methods to derive the <see cref="EdifactFormat"/> from e.g. the Prüfidentifikator
+    /// </summary>
+    public static class EdifactFormatHelper
+    {
+        /// <summary>
+        /// get fact for a message class ID ("Prüfidentifikator")
+        /// </summary>
+        /// <param name="pruefidentifikator">prüfidentifikator, e.g. '11042'</param>
+        /// <returns>the EdifactFormat, e.g. <see cref="EdifactFormat.UTILMD"/> or throws a NotImplementedException iff EdiFormat was found</returns>
+        public static EdifactFormat FromPruefidentifikator(string pruefidentifikator)
+        {
+            if (string.IsNullOrWhiteSpace(pruefidentifikator)) throw new ArgumentNullException(nameof(pruefidentifikator));
+            foreach (EdifactFormat ef in Enum.GetValues(typeof(EdifactFormat)))
+            {
+                if (pruefidentifikator.StartsWith(((int)ef).ToString()))
+                {
+                    return ef;
+                }
+            }
+
+            throw new NotImplementedException($"No matching EdiFormat found for Prüfidentifikator {pruefidentifikator}");
+        }
+    }
+
+    /// <summary>
+    /// A Format Version represents a validity period of a EDIFACT format
+    /// </summary>
+    public enum EdifactFormatVersion
+    {
+        /// <summary>
+        /// format version valid since 2017-10-01
+        /// </summary>
+        FV1710,
+
+        /// <summary>
+        /// format version valid since 2019-04-01
+        /// </summary>
+        FV1904,
+
+        /// <summary>
+        /// format version valid since 2019-12-01 ("Mako2020")
+        /// </summary>
+        FV1912,
+
+        /// <summary>
+        /// format version valid since 2020-04-01
+        /// </summary>
+        FV2004,
+
+        /// <summary>
+        /// Format Version April 2021 (valid since 2021-04-01)
+        /// </summary>
+        FV2104,
+
+        /// <summary>
+        /// Format Version October 2021 (valid since 2021-10-01)
+        /// </summary>
+        FV2110,
+
+        /// <summary>
+        /// Format Version April 2022 (aka MaKo2022)
+        /// </summary>
+        FV2204
+    }
+
+    /// <summary>
+    /// Extension methods for <see cref="EdifactFormatVersion"/>
+    /// </summary>
+    public static class EdifactFormatVersionExtension
+    {
+        /// <summary>
+        /// returns the legacy "MM/YY" string for a <see cref="EdifactFormatVersion"/>.
+        /// </summary>
+        /// <remarks>It's called legacy because its unhandy (modelling enums with leading digits or slashes is complicated and unintuitive to use the month before the year.</remarks>
+        /// <param name="edifactFormatVersion"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public static string ToLegacyVersionString(this EdifactFormatVersion edifactFormatVersion)
+        {
+            return edifactFormatVersion switch
+            {
+                EdifactFormatVersion.FV1710 => "10/17",
+                EdifactFormatVersion.FV1904 => "04/19",
+                EdifactFormatVersion.FV1912 => "12/19",
+                EdifactFormatVersion.FV2004 => "04/20",
+                EdifactFormatVersion.FV2104 => "04/21",
+                EdifactFormatVersion.FV2110 => "10/21",
+                EdifactFormatVersion.FV2204 => "04/22",
+                _ => throw new NotImplementedException($"The legacy format for {edifactFormatVersion} is not yet implemented.")
+            };
+        }
+
+        /// <summary>
+        /// parses the <paramref name="legacyFormatString"/> as <see cref="EdifactFormatVersion"/>.
+        /// If <paramref name="legacyFormatString"/> is null or white space, the current version is returned.
+        /// </summary>
+        /// <param name="legacyFormatString"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public static EdifactFormatVersion ToEdifactFormatVersion(this string legacyFormatString)
+        {
+            if (string.IsNullOrWhiteSpace(legacyFormatString)) return EdifactFormatVersionHelper.GetCurrent();
+            foreach (var efv in Enum.GetValues(typeof(EdifactFormatVersion)).Cast<EdifactFormatVersion>())
+            {
+                if (legacyFormatString == efv.ToLegacyVersionString())
+                {
+                    return efv;
+                }
+            }
+
+            if (Enum.TryParse<EdifactFormatVersion>(legacyFormatString, out var result))
+            {
+                // may we'll ever receive it in the new format. then transformer bee will be the last system to complain ;)
+                return result;
+            }
+
+            throw new NotImplementedException($"The legacy format string '{legacyFormatString}' could not be mapped.");
+        }
+    }
+
+    public static class EdifactFormatVersionHelper
+    {
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV1904"/>
+        /// </summary>
+        private static readonly DateTime Keydate1904 = new DateTime(2019, 3, 31, 22, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV1912"/>
+        /// </summary>
+        private static readonly DateTime Keydate1912 = new DateTime(2019, 11, 30, 23, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2004"/>
+        /// </summary>
+        private static readonly DateTime Keydate2004 = new DateTime(2020, 03, 31, 22, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2104"/>
+        /// </summary>
+        private static readonly DateTime Keydate2104 = new DateTime(2021, 03, 31, 22, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2110"/>
+        /// </summary>
+        private static readonly DateTime KeyDate2110 = new DateTime(2021, 09, 30, 22, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2110"/>
+        /// </summary>
+        private static readonly DateTime KeyDate2204 = new DateTime(2022, 03, 31, 22, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// returns the format version valid as of now.
+        /// </summary>
+        /// <returns>currently valid EdiFormatVersion (the oldest one implemented is <see cref="EdifactFormatVersion.FV1710"/></returns>
+        public static EdifactFormatVersion GetCurrent()
+        {
+            var now = DateTime.UtcNow;
+            if (now > KeyDate2204)
+            {
+                return EdifactFormatVersion.FV2204;
+            }
+            if (now > KeyDate2110)
+            {
+                return EdifactFormatVersion.FV2110;
+            }
+            if (now > Keydate2104)
+            {
+                return EdifactFormatVersion.FV2104;
+            }
+            if (now > Keydate2004)
+            {
+                return EdifactFormatVersion.FV2004;
+            }
+            if (now > Keydate1912)
+            {
+                return EdifactFormatVersion.FV1912;
+            }
+            if (now > Keydate1904)
+            {
+                return EdifactFormatVersion.FV1904;
+            }
+            return EdifactFormatVersion.FV1710;
+        }
+    }
+}

--- a/EDILibraryTests/EDIHelperTests.cs
+++ b/EDILibraryTests/EDIHelperTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using EDILibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -53,7 +54,8 @@ namespace EDILibraryTests
 
         private static readonly JsonSerializerOptions JsonFieldOptions = new()
         {
-            IncludeFields = true
+            IncludeFields = true,
+            Converters = { new JsonStringEnumConverter() }
         };
 
         /// <summary>
@@ -61,7 +63,7 @@ namespace EDILibraryTests
         /// </summary>
         [TestMethod]
         [DataRow(null, null)]
-        [DataRow("foo", "{\"Format\":\"ERROR\"}")]
+        [DataRow("foo", "{\"Format\":null}")]
         [DataRow(
             "UNA:+.? 'UNB+UNOC:3+123456789012345:500+123456789:500+210326:1553+WIM00000000901'UNH+WIM00000000901+UTILMD:D:11A:UN:5.2b'BGM+E03+WIM00000000901'DTM+137:202103261553:203'NAD+MS+123456789012345::293'CTA+IC+:Max Mustermann'COM+max@mustermann.de:EM'NAD+MR+123456789::293'IDE+24+WIMP0000000459'DTM+92:20210401:102'DTM+157:20210401:102'STS+7++ZE8'LOC+172+41234567896'RFF+Z13:11116'SEQ+Z01'CCI+Z30++Z06'",
             "{\"Format\":\"UTILMD\", \"Nachrichtenversion\":\"D\",\"Version\":\"5.2b\", \"Sender\":{\"CodeList\":\"500\",\"ID\":\"123456789012345\"}, \"Freigabenummer\":\"11A\", \"Empfänger\":{\"CodeList\":\"500\",\"ID\":\"123456789\"}, \"ID\":\"WIM00000000901\"}")]

--- a/EDILibraryTests/EDIHelperTests.cs
+++ b/EDILibraryTests/EDIHelperTests.cs
@@ -76,7 +76,7 @@ namespace EDILibraryTests
             {
                 var expected = JsonSerializer.Deserialize<EDIFileInfo>(expectedOutput, JsonFieldOptions);
                 Assert.IsNotNull(expected);
-                if (expected.Format == "ERROR")
+                if (!expected.Format.HasValue)
                 {
                     Assert.AreEqual(expected.Format, actual.Format);
                     Assert.IsTrue(System.Guid.TryParse(actual.Referenz, out _));

--- a/EDILibraryTests/EdifactFormatVersionTests.cs
+++ b/EDILibraryTests/EdifactFormatVersionTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using EDILibrary;
+
+namespace EDILibraryTests
+{
+    /// <summary>
+    /// Tests <see cref="EdifactFormatVersion"/> and <see cref="EdifactFormat"/>
+    /// </summary>
+    [TestClass]
+    public class EdifactFormatVersionTests
+    {
+        [TestMethod]
+        [DataRow("21009", EdifactFormat.IFTSTA)]
+        [DataRow("23001", EdifactFormat.INSRPT)]
+        [DataRow("31001", EdifactFormat.INVOIC)]
+        [DataRow("17002", EdifactFormat.ORDERS)]
+        [DataRow("19002", EdifactFormat.ORDRSP)]
+        [DataRow("27005", EdifactFormat.PRICAT)]
+        [DataRow("11042", EdifactFormat.UTILMD)]
+        [DataRow("13002", EdifactFormat.MSCONS)]
+        [DataRow("35002", EdifactFormat.QUOTES)]
+        [DataRow("15002", EdifactFormat.REQOTE)]
+        [DataRow("33001", EdifactFormat.REMADV)]
+        [DataRow("11042", EdifactFormat.UTILMD)]
+        public void TestPruefiToFormat(string pruefi, EdifactFormat expectedFormat)
+        {
+            var actualFormat = EdifactFormatHelper.FromPruefidentifikator(pruefi);
+            Assert.AreEqual(expectedFormat, actualFormat);
+        }
+
+        [TestMethod]
+        public void NoPruefiNoFormat()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => EdifactFormatHelper.FromPruefidentifikator(null));
+            Assert.ThrowsException<ArgumentNullException>(() => EdifactFormatHelper.FromPruefidentifikator("   "));
+        }
+
+        [TestMethod]
+        public void UnmappedThrowsNotImplemented()
+        {
+            Assert.ThrowsException<NotImplementedException>(() => EdifactFormatHelper.FromPruefidentifikator("88888"));
+        }
+
+        [TestMethod]
+        [DataRow("04/21", EdifactFormatVersion.FV2104)]
+        [DataRow("FV2104", EdifactFormatVersion.FV2104)]
+        [DataRow("04/20", EdifactFormatVersion.FV2004)]
+        [DataRow("FV2004", EdifactFormatVersion.FV2004)]
+        [DataRow("12/19", EdifactFormatVersion.FV1912)]
+        [DataRow("FV1912", EdifactFormatVersion.FV1912)]
+        [DataRow("04/19", EdifactFormatVersion.FV1904)]
+        [DataRow("FV1904", EdifactFormatVersion.FV1904)]
+        [DataRow("10/17", EdifactFormatVersion.FV1710)]
+        [DataRow("FV1710", EdifactFormatVersion.FV1710)]
+        public void TestLegacyStrings(string legacyString, EdifactFormatVersion expectedFormatVersion)
+        {
+            var actualFormatVersion = legacyString.ToEdifactFormatVersion();
+            Assert.AreEqual(expectedFormatVersion, actualFormatVersion);
+            if (!legacyString.StartsWith("FV"))
+            {
+                Assert.AreEqual(legacyString, expectedFormatVersion.ToLegacyVersionString());
+            }
+            else
+            {
+                Assert.AreEqual(legacyString, expectedFormatVersion.ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This does _not_ solve the confusion between MIG versions (like "5.2a") and FormatVersions (like "04/21")