### PR TITLE
Create CODEOWNERS & Automatically Request Dependabot Reviews from C# Developers Review Team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# For a documentation on the CODEOWNERS file in general see:
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+# enforce a review by the documentation team for all changes unless specified differently in a rule further below
+* @Hochfrequenz/c-developers-review-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "c-developers-review-team"
+      - "@Hochfrequenz/c-developers-review-team"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    reviewers:
+      - "c-developers-review-team"


### PR DESCRIPTION
This will automatically assign all new PRs to the codeowners as reviewers.