### PR TITLE
⬆ 👷‍♂️Upgrade CI Actions & Test Project to .NET6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: 6.0.201
       - name: Build/Check for compile errors (dotnet build)
         run: dotnet build --configuration Release

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup .NET 5
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: 6.0.201
       - name: Install dotnet-format
         run: |
           dotnet tool install -g dotnet-format

--- a/.github/workflows/unittests_and_coverage.yml
+++ b/.github/workflows/unittests_and_coverage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@master
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: 6.0.201
       - name: Install dependencies
         run: dotnet restore
       - name: Install coverlet.msbuild in EDILibraryTests

--- a/.github/workflows/unittests_and_coverage.yml
+++ b/.github/workflows/unittests_and_coverage.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@master
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: 6.0.201
       - name: Run Tests
         run: dotnet test --configuration Release
   coverage:

--- a/EDILibraryTests/EDILibraryTests.csproj
+++ b/EDILibraryTests/EDILibraryTests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -16,5 +14,4 @@
     <ItemGroup>
       <ProjectReference Include="..\EDILibrary\EDILibrary.csproj" />
     </ItemGroup>
-
 </Project>


### PR DESCRIPTION
The test & build pipeline were broken:
> error NU3028: Package [...] from source 'https://api.nuget.org/v3/index.json': The repository primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain

Upgrading the Pipelines to .NET6 fixes the problem.