### PR TITLE
Introduce `IEdifactFormatVersionProvider`; 🔥`FV2204`; 🐛 Fix KeyDate Checks

### DIFF
--- a/EDILibrary/EdifactFormatVersion.cs
+++ b/EDILibrary/EdifactFormatVersion.cs
@@ -167,11 +167,6 @@ namespace EDILibrary
         FV2110,
 
         /// <summary>
-        /// Format Version April 2022 (cancelled)
-        /// </summary>
-        FV2204,
-
-        /// <summary>
         /// Format Version October 2022 (aka MaKo2022)
         /// </summary>
         FV2210
@@ -207,7 +202,6 @@ namespace EDILibrary
                 EdifactFormatVersion.FV2004 => "04/20",
                 EdifactFormatVersion.FV2104 => "04/21",
                 EdifactFormatVersion.FV2110 => "10/21",
-                EdifactFormatVersion.FV2204 => "04/22",
                 EdifactFormatVersion.FV2210 => "10/22",
                 _ => throw new NotImplementedException($"The legacy format for {edifactFormatVersion} is not yet implemented.")
             };

--- a/EDILibrary/EdifactFormatVersion.cs
+++ b/EDILibrary/EdifactFormatVersion.cs
@@ -404,7 +404,7 @@ namespace EDILibrary
                 {
                     "5.2e" => EdifactFormatVersion.FV2210,
                     "5.2c" => EdifactFormatVersion.FV2110,
-                    _ =>GetCurrent()
+                    _ => GetCurrent()
                 },
                 EdifactFormat.MSCONS => version switch
                 {
@@ -414,7 +414,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.PARTIN => version switch
                 {
-                    "1.0a" => EdifactFormatVersion.FV2210,                    
+                    "1.0a" => EdifactFormatVersion.FV2210,
                     _ => GetCurrent()
                 },
                 EdifactFormat.IFTSTA => version switch
@@ -455,7 +455,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.ORDCHG => version switch
                 {
-                    "1.0" => EdifactFormatVersion.FV2210,                    
+                    "1.0" => EdifactFormatVersion.FV2210,
                     _ => GetCurrent()
                 },
                 EdifactFormat.ORDERS => version switch

--- a/EDILibrary/EdifactFormatVersion.cs
+++ b/EDILibrary/EdifactFormatVersion.cs
@@ -236,7 +236,7 @@ namespace EDILibrary
         {
             if (string.IsNullOrWhiteSpace(legacyFormatString))
             {
-                return EdifactFormatVersionHelper.GetCurrent();
+                new EdifactFormatVersionHelper().GetCurrent();
             }
 #if NETSTANDARD2_1
             foreach (EdifactFormatVersion efv in Enum.GetValues(typeof(EdifactFormatVersion)).Cast<EdifactFormatVersion>())
@@ -265,7 +265,23 @@ namespace EDILibrary
         }
     }
 
-    public static class EdifactFormatVersionHelper
+    public interface IEdifactFormatVersionProvider
+    {
+        /// <summary>
+        /// returns the valid Edifact Format Version at the given <paramref name="dto"/>
+        /// </summary>
+        /// <param name="dto"></param>
+        /// <returns></returns>
+        public EdifactFormatVersion GetFormatVersion(DateTimeOffset dto);
+
+        /// <summary>
+        /// returns the valid Edifact Format Version used now
+        /// </summary>
+        /// <returns></returns>
+        public EdifactFormatVersion GetCurrent();
+    }
+
+    public class EdifactFormatVersionHelper : IEdifactFormatVersionProvider
     {
         /// <summary>
         /// validity date of <see cref="EdifactFormatVersion.FV1904"/>
@@ -298,44 +314,49 @@ namespace EDILibrary
         /// </summary>
         private static readonly DateTime KeyDate2210 = new(2022, 09, 30, 22, 0, 0, DateTimeKind.Utc);
 
-        /// <summary>
-        /// returns the format version valid as of now.
-        /// </summary>
-        /// <returns>currently valid EdiFormatVersion (the oldest one implemented is <see cref="EdifactFormatVersion.FV1710"/></returns>
-        public static EdifactFormatVersion GetCurrent()
+
+        public EdifactFormatVersion GetFormatVersion(DateTimeOffset keydate)
         {
-            var now = DateTime.UtcNow;
-            if (now > KeyDate2210)
+            if (keydate > KeyDate2210)
             {
                 return EdifactFormatVersion.FV2210;
             }
 
-            if (now > KeyDate2110)
+            if (keydate > KeyDate2110)
             {
                 return EdifactFormatVersion.FV2110;
             }
 
-            if (now > Keydate2104)
+            if (keydate > Keydate2104)
             {
                 return EdifactFormatVersion.FV2104;
             }
 
-            if (now > Keydate2004)
+            if (keydate > Keydate2004)
             {
                 return EdifactFormatVersion.FV2004;
             }
 
-            if (now > Keydate1912)
+            if (keydate > Keydate1912)
             {
                 return EdifactFormatVersion.FV1912;
             }
 
-            if (now > Keydate1904)
+            if (keydate > Keydate1904)
             {
                 return EdifactFormatVersion.FV1904;
             }
 
             return EdifactFormatVersion.FV1710;
+        }
+        /// <summary>
+        /// returns the format version valid as of now.
+        /// </summary>
+        /// <returns>currently valid EdiFormatVersion (the oldest one implemented is <see cref="EdifactFormatVersion.FV1710"/></returns>
+        public EdifactFormatVersion GetCurrent()
+        {
+            var keydate = DateTime.UtcNow;
+            return GetFormatVersion(keydate);
         }
     }
 }

--- a/EDILibrary/EdifactFormatVersion.cs
+++ b/EDILibrary/EdifactFormatVersion.cs
@@ -317,32 +317,32 @@ namespace EDILibrary
 
         public EdifactFormatVersion GetFormatVersion(DateTimeOffset keydate)
         {
-            if (keydate > KeyDate2210)
+            if (keydate >= KeyDate2210)
             {
                 return EdifactFormatVersion.FV2210;
             }
 
-            if (keydate > KeyDate2110)
+            if (keydate >= KeyDate2110)
             {
                 return EdifactFormatVersion.FV2110;
             }
 
-            if (keydate > Keydate2104)
+            if (keydate >= Keydate2104)
             {
                 return EdifactFormatVersion.FV2104;
             }
 
-            if (keydate > Keydate2004)
+            if (keydate >= Keydate2004)
             {
                 return EdifactFormatVersion.FV2004;
             }
 
-            if (keydate > Keydate1912)
+            if (keydate >= Keydate1912)
             {
                 return EdifactFormatVersion.FV1912;
             }
 
-            if (keydate > Keydate1904)
+            if (keydate >= Keydate1904)
             {
                 return EdifactFormatVersion.FV1904;
             }

--- a/EDILibrary/EdifactFormatVersion.cs
+++ b/EDILibrary/EdifactFormatVersion.cs
@@ -169,7 +169,15 @@ namespace EDILibrary
         /// <summary>
         /// Format Version October 2022 (aka MaKo2022)
         /// </summary>
-        FV2210
+        FV2210,
+        /// <summary>
+        /// Format Version April 2023
+        /// </summary>
+        FV2304,
+        /// <summary>
+        /// Format Version October 2023 (ako MaKo2023)
+        /// </summary>
+        FV2310
     }
 
     public class EdifactFormatVersionComparer : IComparer<EdifactFormatVersion>
@@ -203,6 +211,8 @@ namespace EDILibrary
                 EdifactFormatVersion.FV2104 => "04/21",
                 EdifactFormatVersion.FV2110 => "10/21",
                 EdifactFormatVersion.FV2210 => "10/22",
+                EdifactFormatVersion.FV2304 => "04/23",
+                EdifactFormatVersion.FV2310 => "10/23",
                 _ => throw new NotImplementedException($"The legacy format for {edifactFormatVersion} is not yet implemented.")
             };
         }
@@ -269,6 +279,14 @@ namespace EDILibrary
         public EdifactFormatVersion GetFormatVersion(DateTimeOffset dto);
 
         /// <summary>
+        /// returns the valid Edifact Format Version for a given format and version/>
+        /// </summary>
+        /// <param name="format">Edifact format to look for</param>
+        /// <param name="version">the version of the specified format (e.g. 5.2c)</param>
+        /// <returns></returns>
+        public EdifactFormatVersion GetFormatVersion(EdifactFormat format, string version);
+
+        /// <summary>
         /// returns the valid Edifact Format Version used now
         /// </summary>
         /// <returns></returns>
@@ -304,13 +322,32 @@ namespace EDILibrary
 
 
         /// <summary>
-        /// validity date of <see cref="EdifactFormatVersion.FV2110"/>
+        /// validity date of <see cref="EdifactFormatVersion.FV2210"/>
         /// </summary>
         private static readonly DateTime KeyDate2210 = new(2022, 09, 30, 22, 0, 0, DateTimeKind.Utc);
 
 
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2304"/>
+        /// </summary>
+        private static readonly DateTime KeyDate2304 = new(2023, 03, 31, 22, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// validity date of <see cref="EdifactFormatVersion.FV2310"/>
+        /// </summary>
+        private static readonly DateTime KeyDate2310 = new(2023, 09, 30, 22, 0, 0, DateTimeKind.Utc);
+
+
         public EdifactFormatVersion GetFormatVersion(DateTimeOffset keydate)
         {
+            if (keydate >= KeyDate2310)
+            {
+                return EdifactFormatVersion.FV2310;
+            }
+            if (keydate >= KeyDate2304)
+            {
+                return EdifactFormatVersion.FV2304;
+            }
             if (keydate >= KeyDate2210)
             {
                 return EdifactFormatVersion.FV2210;
@@ -351,6 +388,121 @@ namespace EDILibrary
         {
             var keydate = DateTime.UtcNow;
             return GetFormatVersion(keydate);
+        }
+        /// <summary>
+        /// <see cref="IEdifactFormatVersionProvider.GetFormatVersion(EdifactFormat, string)"/>
+        /// does not support anything older than 2110 at the moment
+        /// </summary>
+        /// <param name="format"></param>
+        /// <param name="version"></param>
+        /// <returns></returns>
+        public EdifactFormatVersion GetFormatVersion(EdifactFormat format, string version)
+        {
+            EdifactFormatVersion determinedVersion = format switch
+            {
+                EdifactFormat.UTILMD => version switch
+                {
+                    "5.2e" => EdifactFormatVersion.FV2210,
+                    "5.2c" => EdifactFormatVersion.FV2110,
+                    _ =>GetCurrent()
+                },
+                EdifactFormat.MSCONS => version switch
+                {
+                    "2.4a" => EdifactFormatVersion.FV2210,
+                    "2.3c" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.PARTIN => version switch
+                {
+                    "1.0a" => EdifactFormatVersion.FV2210,                    
+                    _ => GetCurrent()
+                },
+                EdifactFormat.IFTSTA => version switch
+                {
+                    "2.0d" => EdifactFormatVersion.FV2210,
+                    "2.0c" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.APERAK => version switch
+                {
+                    "2.1h" => EdifactFormatVersion.FV2210,
+                    "2.1f" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.COMDIS => version switch
+                {
+                    "1.0b" => EdifactFormatVersion.FV2210,
+                    "1.0a" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.CONTRL => version switch
+                {
+                    "2.0b" => EdifactFormatVersion.FV2210,
+                    "2.0a" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.INSRPT => version switch
+                {
+                    "1.1a" => EdifactFormatVersion.FV2210,
+                    "1.1" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.INVOIC => version switch
+                {
+                    "2.8" => EdifactFormatVersion.FV2210,
+                    "2.7a" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.ORDCHG => version switch
+                {
+                    "1.0" => EdifactFormatVersion.FV2210,                    
+                    _ => GetCurrent()
+                },
+                EdifactFormat.ORDERS => version switch
+                {
+                    "1.2a" => EdifactFormatVersion.FV2210,
+                    "1.1m" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.ORDRSP => version switch
+                {
+                    "1.2a" => EdifactFormatVersion.FV2210,
+                    "1.1k" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.PRICAT => version switch
+                {
+                    "2.0a" => EdifactFormatVersion.FV2210,
+                    "1.1b" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.QUOTES => version switch
+                {
+                    "1.2" => EdifactFormatVersion.FV2210,
+                    "1.1b" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.REMADV => version switch
+                {
+                    "2.9" => EdifactFormatVersion.FV2210,
+                    "2.8" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.REQOTE => version switch
+                {
+                    "1.2" => EdifactFormatVersion.FV2210,
+                    "1.1d" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                EdifactFormat.UTILTS => version switch
+                {
+                    "1.1a" => EdifactFormatVersion.FV2210,
+                    "1.0a" => EdifactFormatVersion.FV2110,
+                    _ => GetCurrent()
+                },
+                _ => GetCurrent()
+            };
+            return determinedVersion;
         }
     }
 }

--- a/EDILibraryTests/EDILibraryTests.csproj
+++ b/EDILibraryTests/EDILibraryTests.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="Moq" Version="4.18.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
         <PackageReference Include="coverlet.collector" Version="3.1.2" />

--- a/EDILibraryTests/EdifactFormatVersionTests.cs
+++ b/EDILibraryTests/EdifactFormatVersionTests.cs
@@ -127,5 +127,19 @@ namespace EDILibraryTests
             versionProviderMock.Setup(vp => vp.GetCurrent()).Returns(EdifactFormatVersion.FV1904);
             Assert.AreEqual(EdifactFormatVersion.FV1904, ActualCode(versionProviderMock.Object));
         }
+
+        /// <summary>
+        /// Test that the <see cref="EdifactFormatVersionHelper"/> returns <see cref="EdifactFormatVersion.FV2110"/> in for 2021-10-01&lt;=dt&lt;2022-10-01 (german local time)
+        /// </summary>
+        [TestMethod]
+        public void TestFV2110()
+        {
+            IEdifactFormatVersionProvider versionProvider = new EdifactFormatVersionHelper();
+            Assert.AreEqual(EdifactFormatVersion.FV2104, versionProvider.GetFormatVersion(new DateTimeOffset(2021, 9, 30, 21, 59, 59, TimeSpan.Zero)));
+            Assert.AreEqual(EdifactFormatVersion.FV2110, versionProvider.GetFormatVersion(new DateTimeOffset(2021, 9, 30, 22, 0, 0, TimeSpan.Zero)));
+            Assert.AreEqual(EdifactFormatVersion.FV2110, versionProvider.GetFormatVersion(new DateTimeOffset(2022, 3, 31, 22, 0, 0, TimeSpan.Zero)));
+            Assert.AreEqual(EdifactFormatVersion.FV2110, versionProvider.GetFormatVersion(new DateTimeOffset(2022, 9, 30, 21, 59, 59, TimeSpan.Zero)));
+            Assert.AreEqual(EdifactFormatVersion.FV2210, versionProvider.GetFormatVersion(new DateTimeOffset(2022, 9, 30, 22, 0, 0, TimeSpan.Zero)));
+        }
     }
 }

--- a/EDILibraryTests/EdifactFormatVersionTests.cs
+++ b/EDILibraryTests/EdifactFormatVersionTests.cs
@@ -106,5 +106,26 @@ namespace EDILibraryTests
                 Assert.AreEqual(legacyString, expectedFormatVersion.ToString());
             }
         }
+
+        /// <summary>
+        /// this is just a placeholder for actual business logic
+        /// </summary>
+        /// <param name="versionProvider"></param>
+        /// <returns></returns>
+        private EdifactFormatVersion ActualCode(IEdifactFormatVersionProvider versionProvider)
+        {
+            return versionProvider.GetCurrent();
+        }
+
+        /// <summary>
+        /// This test is just to show how the <see cref="EdifactFormatHelper"/> is thought to be used: behind an interface!
+        /// </summary>
+        [TestMethod]
+        public void TestMockingVersionProvider()
+        {
+            var versionProviderMock = new Moq.Mock<IEdifactFormatVersionProvider>();
+            versionProviderMock.Setup(vp => vp.GetCurrent()).Returns(EdifactFormatVersion.FV1904);
+            Assert.AreEqual(EdifactFormatVersion.FV1904, ActualCode(versionProviderMock.Object));
+        }
     }
 }

--- a/EDILibraryTests/EdifactFormatVersionTests.cs
+++ b/EDILibraryTests/EdifactFormatVersionTests.cs
@@ -53,7 +53,6 @@ namespace EDILibraryTests
                 EdifactFormatVersion.FV2004,
                 EdifactFormatVersion.FV2104,
                 EdifactFormatVersion.FV2110,
-                EdifactFormatVersion.FV2204,
                 EdifactFormatVersion.FV2210
             };
             var comparer = new EdifactFormatVersionComparer();
@@ -82,7 +81,6 @@ namespace EDILibraryTests
 
         [TestMethod]
         [DataRow("10/22", EdifactFormatVersion.FV2210)]
-        [DataRow("04/22", EdifactFormatVersion.FV2204)]
         [DataRow("04/21", EdifactFormatVersion.FV2104)]
         [DataRow("FV2104", EdifactFormatVersion.FV2104)]
         [DataRow("04/20", EdifactFormatVersion.FV2004)]


### PR DESCRIPTION
This should make unit testing our code easier because we can use mocks to switch between the FormatVersions used instead of trying to mock DateTime.UtcNow (which is not fun at all)