### PR TITLE
chore: make non-async method not async

### DIFF
--- a/EDILibraryTests/TestSpartenFinder.cs
+++ b/EDILibraryTests/TestSpartenFinder.cs
@@ -24,7 +24,7 @@ namespace EDILibraryTests
         [DataRow("4041408700013", "4038777000004", Sparte.GAS)]
         [DataRow("4260016042005", "4041408700013", Sparte.GAS)]
         [DataRow("5260016042005", "4041408700013", Sparte.WASSER)]
-        public async Task TestSparte(string sender, string receiver, Sparte expectedSparte)
+        public void TestSparte(string sender, string receiver, Sparte expectedSparte)
         {
             Sparten s = new();
             s.STROM.Add("4033872000041");


### PR DESCRIPTION
/home/runner/work/EDILibrary/EDILibrary/EDILibraryTests/TestSpartenFinder.cs(27,27): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread. [/home/runner/work/EDILibrary/EDILibrary/EDILibraryTests/EDILibraryTests.csproj]