### PR TITLE
feat: Add FV2610 version valid from 2026-10-01

### DIFF
--- a/EDILibrary/EdifactFormatVersion.cs
+++ b/EDILibrary/EdifactFormatVersion.cs
@@ -237,6 +237,11 @@ namespace EDILibrary
         /// Format Version valid since April 2026
         /// </summary>
         FV2604,
+
+        /// <summary>
+        /// Format Version valid since October 2026
+        /// </summary>
+        FV2610,
     }
 
     public class EdifactFormatVersionComparer : IComparer<EdifactFormatVersion>
@@ -277,6 +282,7 @@ namespace EDILibrary
                 EdifactFormatVersion.FV2504 => "04/25",
                 EdifactFormatVersion.FV2510 => "10/25",
                 EdifactFormatVersion.FV2604 => "04/26",
+                EdifactFormatVersion.FV2610 => "10/26",
                 _ => throw new NotImplementedException(
                     $"The legacy format for {edifactFormatVersion} is not yet implemented."
                 ),
@@ -535,8 +541,26 @@ namespace EDILibrary
             DateTimeKind.Utc
         );
 
+        /// <summary>
+        /// validity start date of <see cref="EdifactFormatVersion.FV2610"/>
+        /// </summary>
+        private static readonly DateTime KeyDate2610 = new(
+            2026,
+            09,
+            30,
+            22,
+            0,
+            0,
+            DateTimeKind.Utc
+        );
+
         public EdifactFormatVersion GetFormatVersion(DateTimeOffset keydate)
         {
+            if (keydate >= KeyDate2610)
+            {
+                return EdifactFormatVersion.FV2610;
+            }
+
             if (keydate >= KeyDate2604)
             {
                 return EdifactFormatVersion.FV2604;

--- a/EDILibraryTests/EdifactFormatVersionTests.cs
+++ b/EDILibraryTests/EdifactFormatVersionTests.cs
@@ -83,6 +83,7 @@ namespace EDILibraryTests
                 EdifactFormatVersion.FV2504,
                 EdifactFormatVersion.FV2510,
                 EdifactFormatVersion.FV2604,
+                EdifactFormatVersion.FV2610,
             };
             var comparer = new EdifactFormatVersionComparer();
             for (int i = 0; i < expectedNaturalOrder.Count - 1; i++)
@@ -134,6 +135,7 @@ namespace EDILibraryTests
         [DataRow("04/25", EdifactFormatVersion.FV2504)]
         [DataRow("10/25", EdifactFormatVersion.FV2510)]
         [DataRow("04/26", EdifactFormatVersion.FV2604)]
+        [DataRow("10/26", EdifactFormatVersion.FV2610)]
         public void TestLegacyStrings(
             string legacyString,
             EdifactFormatVersion expectedFormatVersion
@@ -189,6 +191,7 @@ namespace EDILibraryTests
         [DataRow("2025-06-05T22:00:00+00:00", EdifactFormatVersion.FV2504)]
         [DataRow("2025-09-30T22:00:00+00:00", EdifactFormatVersion.FV2510)]
         [DataRow("2026-03-31T22:00:00+00:00", EdifactFormatVersion.FV2604)]
+        [DataRow("2026-09-30T22:00:00+00:00", EdifactFormatVersion.FV2610)]
         public void TestFormatVersionProvider(
             string dateTimeOffset,
             EdifactFormatVersion expectedVersion


### PR DESCRIPTION
## Summary

- Add `FV2610` to `EdifactFormatVersion` enum (valid from 2026-10-01)
- Add key date `2026-09-30T22:00:00Z` and update `GetFormatVersion` to return `FV2610` for dates on/after that
- Add legacy string mapping `"10/26"` ↔ `FV2610`
- Update tests: ordering, legacy string parsing, format version provider

Mirror of Hochfrequenz/efoli#98 for the C# library.

## Test plan

- [x] `TestFormatVersionOrder` — FV2610 is after FV2604
- [x] `TestLegacyStrings` — `"10/26"` maps to FV2610
- [x] `TestFormatVersionProvider` — `2026-09-30T22:00:00+00:00` returns FV2610