### PR TITLE
fix: use LogDebug for expected missing template files and add null guard

### DIFF
--- a/EDIFileLoader/StorageNetLoader.cs
+++ b/EDIFileLoader/StorageNetLoader.cs
@@ -118,6 +118,10 @@ namespace EDIFileLoader
             await using var s = new MemoryStream();
             Logger.LogDebug($"Reading path {path}");
             await using Stream ss = await Storage.OpenReadAsync(path);
+            if (ss == null)
+            {
+                throw new FileNotFoundException($"Storage returned null stream for path '{path}'");
+            }
             Logger.LogDebug("Copying to stream");
             await ss.CopyToAsync(s);
             return Encoding.UTF8.GetString(s.ToArray());
@@ -248,7 +252,7 @@ namespace EDIFileLoader
             }
             catch (Exception exc)
             {
-                Logger.LogWarning(exc, $"Could not load edi template from storage: {exc.Message}");
+                Logger.LogDebug(exc, $"Could not load edi template from storage: {exc.Message}");
                 // why should we raise a meaningful error message when we can just return an empty string and fail somewhere else instead of the place where the error occured?
                 return "";
             }


### PR DESCRIPTION
## Summary
- `GetUTF8TextFromPath`: added null guard that throws a meaningful `FileNotFoundException` when `Storage.OpenReadAsync` returns `null` for a missing path (instead of an opaque `NullReferenceException`)
- `LoadJSONTemplate` catch block: downgraded log level from `LogWarning` → `LogDebug`, since missing PID-specific template files (e.g. `1025/11016.json`) are expected and handled gracefully by `EdiJsonMapper.CreateFromJson`

## Context
`EdiJsonMapper.CreateFromJson` always tries to load a PID-specific JSON mask file. When it doesn't exist, `Storage.Net`'s `LocalDiskBlobStorage.OpenReadAsync` returns `null`, causing a `NullReferenceException` that was caught and logged at Warning level. This warning fires on every BO4E→EDI conversion even though the missing file is expected. The log level change in `3b306e3` (2.2.0→2.6.0 bump) made this previously invisible noise surface as a Warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)