### PR TITLE
fix: make StorageNetLoader cache fully thread-safe

### DIFF
--- a/EDIFileLoader/StorageNetLoader.cs
+++ b/EDIFileLoader/StorageNetLoader.cs
@@ -32,10 +32,15 @@ namespace EDIFileLoader
         protected ILogger Logger { get; set; }
 
         /// <summary>
-        /// Cache dictionary to not download every file again
+        /// Cache dictionary to not download every file again.
+        /// Both outer and inner dictionaries are thread-safe to support concurrent access
+        /// from parallel test runners and multi-threaded applications.
         /// </summary>
-        protected ConcurrentDictionary<string, Dictionary<string, string>> Cache { get; set; } =
-            new ConcurrentDictionary<string, Dictionary<string, string>>();
+        protected ConcurrentDictionary<
+            string,
+            ConcurrentDictionary<string, string>
+        > Cache { get; set; } =
+            new ConcurrentDictionary<string, ConcurrentDictionary<string, string>>();
 
         /// <summary>
         /// JsonSerializer options
@@ -80,9 +85,9 @@ namespace EDIFileLoader
                     {
                         if (folder.IsFolder)
                         {
-                            Cache.TryAdd(
+                            var innerCache = Cache.GetOrAdd(
                                 folder.Name.TrimEnd('/'),
-                                new Dictionary<string, string>()
+                                _ => new ConcurrentDictionary<string, string>()
                             );
                             foreach (
                                 var blob in await Storage.ListAsync(
@@ -99,7 +104,7 @@ namespace EDIFileLoader
                                 }
 
                                 string text = await GetUTF8TextFromPath(blob.FullPath);
-                                Cache[folder.Name.TrimEnd('/')].TryAdd(blob.Name, text);
+                                innerCache.TryAdd(blob.Name, text);
                             }
                         }
                     })
@@ -164,16 +169,10 @@ namespace EDIFileLoader
                 text = EDIHelper.RemoveByteOrderMark(text);
                 if (Cache != null)
                 {
-                    if (!Cache.ContainsKey("edi"))
-                    {
-                        Cache["edi"] = new Dictionary<string, string>();
-                    }
-                    var ediCache = Cache["edi"];
-                    if (ediCache == null)
-                    {
-                        ediCache = new Dictionary<string, string>();
-                    }
-
+                    var ediCache = Cache.GetOrAdd(
+                        "edi",
+                        _ => new ConcurrentDictionary<string, string>()
+                    );
                     ediCache[
                         Path.Combine(
                                 "edi",
@@ -236,16 +235,10 @@ namespace EDIFileLoader
                 text = EDIHelper.RemoveByteOrderMark(text);
                 if (Cache != null)
                 {
-                    if (!Cache.ContainsKey(version.Replace("/", "")))
-                    {
-                        Cache[version.Replace("/", "")] = new Dictionary<string, string>();
-                    }
-                    var ediCache = Cache[version.Replace("/", "")];
-                    if (ediCache == null)
-                    {
-                        ediCache = new Dictionary<string, string>();
-                    }
-
+                    var ediCache = Cache.GetOrAdd(
+                        version.Replace("/", ""),
+                        _ => new ConcurrentDictionary<string, string>()
+                    );
                     ediCache[fileName.Replace("\\", "/")] = text;
                 }
                 return text;
@@ -295,16 +288,10 @@ namespace EDIFileLoader
                 text = EDIHelper.RemoveByteOrderMark(text);
                 if (Cache != null)
                 {
-                    if (!Cache.ContainsKey("maus"))
-                    {
-                        Cache["maus"] = new Dictionary<string, string>();
-                    }
-                    var ediCache = Cache["maus"];
-                    if (ediCache == null)
-                    {
-                        ediCache = new Dictionary<string, string>();
-                    }
-
+                    var ediCache = Cache.GetOrAdd(
+                        "maus",
+                        _ => new ConcurrentDictionary<string, string>()
+                    );
                     ediCache[
                         Path.Combine(version.ToString(), format.ToString(), pid + "_maus.json")
                     ] = text;


### PR DESCRIPTION
## Summary

- Changed inner cache dictionaries from `Dictionary<string, string>` to `ConcurrentDictionary<string, string>` to prevent race conditions when multiple threads access the cache simultaneously
- Replaced `ContainsKey` + assign pattern with atomic `GetOrAdd` in all cache-miss paths (`LoadEDITemplate`, `LoadJSONTemplate`, `LoadMausTemplate`)
- Fixed `PreloadCache()` to use `GetOrAdd` and write directly to the returned reference

## Problem

The `StorageNetLoader.Cache` field was:
```csharp
ConcurrentDictionary<string, Dictionary<string, string>> Cache
```

While the **outer** dictionary was thread-safe (`ConcurrentDictionary`), the **inner** dictionaries were plain `Dictionary<string, string>` — not thread-safe for concurrent reads/writes.

When multiple threads hit a cold cache simultaneously (e.g. parallel test runners on CI with 4+ cores), this causes:
- Corrupted internal Dictionary state
- `KeyNotFoundException` on valid keys  
- Intermittent test failures that only reproduce under parallel load

## Fix

```csharp
ConcurrentDictionary<string, ConcurrentDictionary<string, string>> Cache
```

All cache-miss paths now use `Cache.GetOrAdd(key, _ => new ConcurrentDictionary<string, string>())` instead of the race-prone `ContainsKey` + manual assignment.

## Testing

- All 99 EDILibrary tests pass
- This fix resolves intermittent CI failures in downstream consumers (e.g. edifact-bo4e-converter parallel tests)