### PR TITLE
feat: add FV2610 MIG version mappings

### DIFF
--- a/EDILibrary/EdifactFormatVersion.cs
+++ b/EDILibrary/EdifactFormatVersion.cs
@@ -652,6 +652,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.UTILMDG => version switch
                 {
+                    "G1.2" => EdifactFormatVersion.FV2610,
                     "G1.1" => EdifactFormatVersion.FV2604,
                     "G1.0a" => EdifactFormatVersion.FV2310,
                     _ => GetCurrent(),
@@ -665,6 +666,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.UTILMDS => version switch
                 {
+                    "S2.2" => EdifactFormatVersion.FV2610,
                     "S2.1" => EdifactFormatVersion.FV2504,
                     "S2.0" => EdifactFormatVersion.FV2504,
                     "S1.1a" => EdifactFormatVersion.FV2404,
@@ -673,6 +675,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.MSCONS => version switch
                 {
+                    "2.5" => EdifactFormatVersion.FV2610,
                     "2.4c" => EdifactFormatVersion.FV2404,
                     "2.4b" => EdifactFormatVersion.FV2310,
                     "2.4a" => EdifactFormatVersion.FV2210,
@@ -681,6 +684,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.PARTIN => version switch
                 {
+                    "1.1" => EdifactFormatVersion.FV2610,
                     "1.0f" => EdifactFormatVersion.FV2604,
                     "1.0e" => EdifactFormatVersion.FV2504,
                     "1.0d" => EdifactFormatVersion.FV2404,
@@ -690,6 +694,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.IFTSTA => version switch
                 {
+                    "2.1" => EdifactFormatVersion.FV2610,
                     "2.0g" => EdifactFormatVersion.FV2510,
                     "2.0f" => EdifactFormatVersion.FV2504,
                     "2.0e" => EdifactFormatVersion.FV2404,
@@ -699,6 +704,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.APERAK => version switch
                 {
+                    "2.2" => EdifactFormatVersion.FV2610,
                     "2.1i" => EdifactFormatVersion.FV2504,
                     "2.1h" => EdifactFormatVersion.FV2210,
                     "2.1f" => EdifactFormatVersion.FV2110,
@@ -740,12 +746,14 @@ namespace EDILibrary
                 },
                 EdifactFormat.ORDCHG => version switch
                 {
+                    "1.2" => EdifactFormatVersion.FV2610,
                     "1.1" => EdifactFormatVersion.FV2310,
                     "1.0" => EdifactFormatVersion.FV2210,
                     _ => GetCurrent(),
                 },
                 EdifactFormat.ORDERS => version switch
                 {
+                    "1.4c" => EdifactFormatVersion.FV2610,
                     "1.4b" => EdifactFormatVersion.FV2510,
                     "1.4a" => EdifactFormatVersion.FV2504,
                     "1.4" => EdifactFormatVersion.FV2504,
@@ -757,6 +765,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.ORDRSP => version switch
                 {
+                    "1.4c" => EdifactFormatVersion.FV2610,
                     "1.4b" => EdifactFormatVersion.FV2604,
                     "1.4a" => EdifactFormatVersion.FV2510,
                     "1.4" => EdifactFormatVersion.FV2504,
@@ -768,6 +777,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.PRICAT => version switch
                 {
+                    "2.1" => EdifactFormatVersion.FV2610,
                     "2.0e" => EdifactFormatVersion.FV2510,
                     "2.0d" => EdifactFormatVersion.FV2504,
                     "2.0c" => EdifactFormatVersion.FV2310,
@@ -778,6 +788,7 @@ namespace EDILibrary
                 },
                 EdifactFormat.QUOTES => version switch
                 {
+                    "1.3c" => EdifactFormatVersion.FV2610,
                     "1.3b" => EdifactFormatVersion.FV2510,
                     "1.3a" => EdifactFormatVersion.FV2504,
                     "1.3" => EdifactFormatVersion.FV2310,

--- a/EDILibraryTests/EdifactFormatVersionTests.cs
+++ b/EDILibraryTests/EdifactFormatVersionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AwesomeAssertions;
 using EDILibrary;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -200,6 +201,28 @@ namespace EDILibraryTests
             IEdifactFormatVersionProvider versionProvider = new EdifactFormatVersionHelper();
             DateTimeOffset date = DateTimeOffset.Parse(dateTimeOffset);
             Assert.AreEqual(expectedVersion, versionProvider.GetFormatVersion(date));
+        }
+
+        [TestMethod]
+        [DataRow(EdifactFormat.APERAK, "2.2", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.IFTSTA, "2.1", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.MSCONS, "2.5", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.ORDCHG, "1.2", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.ORDERS, "1.4c", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.ORDRSP, "1.4c", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.PARTIN, "1.1", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.PRICAT, "2.1", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.QUOTES, "1.3c", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.UTILMDG, "G1.2", EdifactFormatVersion.FV2610)]
+        [DataRow(EdifactFormat.UTILMDS, "S2.2", EdifactFormatVersion.FV2610)]
+        public void TestFormatVersionByMigVersion(
+            EdifactFormat format,
+            string migVersion,
+            EdifactFormatVersion expectedVersion
+        )
+        {
+            IEdifactFormatVersionProvider versionProvider = new EdifactFormatVersionHelper();
+            versionProvider.GetFormatVersion(format, migVersion).Should().Be(expectedVersion);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add FV2610 mappings for new MIG version strings in EdifactFormatVersionHelper.GetFormatVersion(format, version)
- add parameterized tests for FV2610 MIG version lookups using AwesomeAssertions

## Raw spec check
- independently checked against ../xml-migs-and-ahbs/FV2610 *_MIG_*.xml files
- confirmed FV2610 mappings for APERAK 2.2, IFTSTA 2.1, MSCONS 2.5, ORDCHG 1.2, ORDERS/ORDRSP 1.4c, PARTIN 1.1, PRICAT 2.1, QUOTES 1.3c, UTILMDG G1.2, UTILMDS S2.2
- left carried-forward older MIG versions mapped to their existing introduction format versions

## Verification
- dotnet test --filter FullyQualifiedName~EdifactFormatVersionTests
- dotnet test (110 passed, 0 failed; existing warnings remain)