### PR TITLE
feat: add missing FV2610 Pruefidentifikatoren

### DIFF
--- a/EDILibrary/Constants/German/Pruefidentifikatoren.cs
+++ b/EDILibrary/Constants/German/Pruefidentifikatoren.cs
@@ -941,8 +941,7 @@ namespace EDILibrary.Constants.German
         public const string UTILMD_55692_GpkeTeil4_RueckmeldungAnfragePaketIdDerMaloLfAnNb =
             "55692";
         public const string UTILMD_55693_GpkeTeil4_AenderungDatenDerTrLfAnNb = "55693";
-        public const string UTILMD_55694_GpkeTeil4_Rueckmeldung_AnfrageDatenDerTrNbAnLf =
-            "55694";
+        public const string UTILMD_55694_GpkeTeil4_Rueckmeldung_AnfrageDatenDerTrNbAnLf = "55694";
 
         #endregion
 

--- a/EDILibrary/Constants/German/Pruefidentifikatoren.cs
+++ b/EDILibrary/Constants/German/Pruefidentifikatoren.cs
@@ -940,6 +940,9 @@ namespace EDILibrary.Constants.German
         public const string UTILMD_55691_GpkeTeil4_AenderungPaketIdDerMaloNbAnLf = "55691";
         public const string UTILMD_55692_GpkeTeil4_RueckmeldungAnfragePaketIdDerMaloLfAnNb =
             "55692";
+        public const string UTILMD_55693_GpkeTeil4_AenderungDatenDerTrLfAnNb = "55693";
+        public const string UTILMD_55694_GpkeTeil4_Rueckmeldung_AnfrageDatenDerTrNbAnLf =
+            "55694";
 
         #endregion
 
@@ -1066,6 +1069,7 @@ namespace EDILibrary.Constants.German
             "44181";
         public const string UTILMD_44182_SdaeGas_AblehnungDerAnfrageDerKomplexenMarktlokationsstrukturNbAnLf =
             "44182";
+        public const string UTILMD_44183_WimGas_EndeMsbVonNb = "44183";
 
         #endregion
 

--- a/EDILibraryTests/PruefidentifikatorenTests.cs
+++ b/EDILibraryTests/PruefidentifikatorenTests.cs
@@ -11,9 +11,11 @@ namespace EDILibraryTests
         public void TestMissingFv2610Pruefidentifikatoren()
         {
             Pruefidentifikatoren.UTILMD_44183_WimGas_EndeMsbVonNb.Should().Be("44183");
-            Pruefidentifikatoren.UTILMD_55693_GpkeTeil4_AenderungDatenDerTrLfAnNb.Should()
+            Pruefidentifikatoren
+                .UTILMD_55693_GpkeTeil4_AenderungDatenDerTrLfAnNb.Should()
                 .Be("55693");
-            Pruefidentifikatoren.UTILMD_55694_GpkeTeil4_Rueckmeldung_AnfrageDatenDerTrNbAnLf.Should()
+            Pruefidentifikatoren
+                .UTILMD_55694_GpkeTeil4_Rueckmeldung_AnfrageDatenDerTrNbAnLf.Should()
                 .Be("55694");
         }
     }

--- a/EDILibraryTests/PruefidentifikatorenTests.cs
+++ b/EDILibraryTests/PruefidentifikatorenTests.cs
@@ -1,0 +1,20 @@
+using AwesomeAssertions;
+using EDILibrary.Constants.German;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EDILibraryTests
+{
+    [TestClass]
+    public class PruefidentifikatorenTests
+    {
+        [TestMethod]
+        public void TestMissingFv2610Pruefidentifikatoren()
+        {
+            Pruefidentifikatoren.UTILMD_44183_WimGas_EndeMsbVonNb.Should().Be("44183");
+            Pruefidentifikatoren.UTILMD_55693_GpkeTeil4_AenderungDatenDerTrLfAnNb.Should()
+                .Be("55693");
+            Pruefidentifikatoren.UTILMD_55694_GpkeTeil4_Rueckmeldung_AnfrageDatenDerTrNbAnLf.Should()
+                .Be("55694");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add missing FV2610 Pruefidentifikatoren constants for 44183, 55693, and 55694
- add a constants test using AwesomeAssertions

## Raw spec check
- independently checked all non-empty Pruefidentifikator attributes in ../xml-migs-and-ahbs/FV2610 *_AHB_*.xml files
- confirmed the branch adds exactly the missing constants 44183, 55693, and 55694
- confirmed no FV2610 Pruefidentifikator values remain missing after these additions

## Source evidence
- 44183: FV2610/UTILMD_AHB_Gas_1_2_20260401.xml, Ende MSB von NB, NB an MSB
- 55693: FV2610/UTILMD_AHB_Strom_2_2_20260401.xml, Änderung Daten der TR, LF an NB
- 55694: FV2610/UTILMD_AHB_Strom_2_2_20260401.xml, Rückmeldung/Anfrage Daten der TR, NB an LF

## Verification
- dotnet test EDILibraryTests\\EDILibraryTests.csproj --filter FullyQualifiedName~PruefidentifikatorenTests
- dotnet test (100 passed, 0 failed; existing warnings remain)