### PR TITLE
fix(DEV-117193): escape control characters in SerializeToJSON output

### DIFF
--- a/EDILibrary/IEdiObject.cs
+++ b/EDILibrary/IEdiObject.cs
@@ -184,7 +184,35 @@ namespace EDILibrary
 
         protected static string escapeSpecialChars(string value)
         {
-            return value.Replace("\"", "\\\"");
+            var sb = new StringBuilder(value.Length);
+            foreach (char c in value)
+            {
+                switch (c)
+                {
+                    case '\\':
+                        sb.Append("\\\\");
+                        break;
+                    case '"':
+                        sb.Append("\\\"");
+                        break;
+                    case '\n':
+                        sb.Append("\\n");
+                        break;
+                    case '\r':
+                        sb.Append("\\r");
+                        break;
+                    case '\t':
+                        sb.Append("\\t");
+                        break;
+                    default:
+                        if (c < 0x20)
+                            sb.Append($"\\u{(int)c:X4}");
+                        else
+                            sb.Append(c);
+                        break;
+                }
+            }
+            return sb.ToString();
         }
 
         protected StringBuilder _builder;
@@ -329,7 +357,7 @@ namespace EDILibrary
                     "\""
                         + elem.Attribute("name").Value
                         + "\" : \""
-                        + elem.Value
+                        + escapeSpecialChars(elem.Value)
                         + "\""
                         + (i != 0 || hasClass ? "," : "")
                 );

--- a/EDILibraryTests/SerializeToJsonTests.cs
+++ b/EDILibraryTests/SerializeToJsonTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Xml.Linq;
+using EDILibrary;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EDILibraryTests
+{
+    [TestClass]
+    public class SerializeToJsonTests
+    {
+        [TestMethod]
+        public void SerializeToJSON_WithNewlineInField_ProducesValidJson()
+        {
+            var obj = new EdiObject("Test", new XElement("root"), "test-key");
+            obj.Fields["Freitext"] = new List<string> { "Zeile 1\nZeile 2" };
+
+            var json = obj.SerializeToJSON();
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsTrue(root.TryGetProperty("Dokument", out _));
+        }
+
+        [TestMethod]
+        public void SerializeToJSON_WithTabInField_ProducesValidJson()
+        {
+            var obj = new EdiObject("Test", new XElement("root"), "test-key");
+            obj.Fields["Text"] = new List<string> { "Spalte1\tSpalte2" };
+
+            var json = obj.SerializeToJSON();
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsTrue(root.TryGetProperty("Dokument", out _));
+        }
+
+        [TestMethod]
+        public void SerializeToJSON_WithCarriageReturnInField_ProducesValidJson()
+        {
+            var obj = new EdiObject("Test", new XElement("root"), "test-key");
+            obj.Fields["Text"] = new List<string> { "Zeile 1\rZeile 2" };
+
+            var json = obj.SerializeToJSON();
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsTrue(root.TryGetProperty("Dokument", out _));
+        }
+
+        [TestMethod]
+        public void SerializeToJSON_WithBackslashInField_ProducesValidJson()
+        {
+            var obj = new EdiObject("Test", new XElement("root"), "test-key");
+            obj.Fields["Path"] = new List<string> { @"C:\Users\test" };
+
+            var json = obj.SerializeToJSON();
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsTrue(root.TryGetProperty("Dokument", out _));
+        }
+
+        [TestMethod]
+        public void SerializeToJSON_WithControlCharInField_ProducesValidJson()
+        {
+            var obj = new EdiObject("Test", new XElement("root"), "test-key");
+            obj.Fields["Data"] = new List<string> { "text\u000Bmore" };
+
+            var json = obj.SerializeToJSON();
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsTrue(root.TryGetProperty("Dokument", out _));
+        }
+
+        [TestMethod]
+        public void SerializeToJSON_WithQuoteInField_ProducesValidJson()
+        {
+            var obj = new EdiObject("Test", new XElement("root"), "test-key");
+            obj.Fields["Name"] = new List<string> { "Max \"Mustermann\"" };
+
+            var json = obj.SerializeToJSON();
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsTrue(root.TryGetProperty("Dokument", out _));
+        }
+
+        [TestMethod]
+        public void SerializeToJSON_WithMultipleControlCharsInField_ProducesValidJson()
+        {
+            var obj = new EdiObject("Test", new XElement("root"), "test-key");
+            obj.Fields["Freitext"] = new List<string>
+            {
+                "Zeile 1\nZeile 2\n\r\nTab:\tEnde\\Backslash",
+            };
+
+            var json = obj.SerializeToJSON();
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            Assert.IsTrue(root.TryGetProperty("Dokument", out _));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`SerializeToJSON` produces invalid JSON when an EDIFACT field contains control characters like `0x0A` (LF), `0x0D` (CR), `0x09` (TAB), or any other control character (0x00-0x1F). `System.Text.Json.JsonObject.Parse` throws `JsonReaderException` because unescaped control characters are not allowed in JSON strings.

This occurs in practice in FTX free-text segments and causes the `edifact-bo4e-converter` to abort conversion.

## Root Cause

`escapeSpecialChars` only escapes `"` -> `\"`, but not:
- `\\` (backslash)
- `\n` (0x0A), `\r` (0x0D), `\t` (0x09)
- Other control characters (0x00-0x1F)

Additionally, `RecurseJSON(XElement)` does not call `escapeSpecialChars` at all - field values are written raw into the JSON string.

## Changes

### `IEdiObject.cs`
- `escapeSpecialChars` now escapes all JSON-dangerous characters
- `RecurseJSON(XElement)` now calls `escapeSpecialChars` for field values

### Tests
- 7 new tests in `SerializeToJsonTests.cs` for `SerializeToJSON` with:
  - Newline, Tab, Carriage Return, Backslash, Quotes, any Control Char, combinations
  - Each test parses the result with `JsonDocument.Parse` to verify validity

## Verification
- All 7 new tests: ✅
- All 99 existing tests: ✅